### PR TITLE
Expand roles and personas in documentation

### DIFF
--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -75,7 +75,117 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
+## Scrum Master / Agile Coach
+
+### Role Summary
+Facilitates agile ceremonies, supports process improvement, removes impediments, and coaches the team on agile best practices.
+
+### Responsibilities
+- Guide team through daily standups, planning, reviews, and retrospectives
+- Coach on agile principles and continuous improvement
+- Remove barriers and help resolve blockers
+- Foster psychological safety and collaboration
+
+### Goals
+- Increase team velocity and predictability
+- Build a learning, adaptive team culture
+
+### Typical Communication
+- Agile ceremonies and retros
+- Impediment log, team health checks
+- 1:1s with team members
+
+### Interaction Points
+- Works closely with PM, Developers, and Product Managers to support delivery
+- Escalates systemic blockers to Project Manager
+
+---
+
+## UX/UI Designer
+
+### Role Summary
+Owns the creation of user experience and interface design artifacts, ensuring cohesive and accessible product experiences.
+
+### Responsibilities
+- Design wireframes, prototypes, and detailed UI specifications
+- Conduct user research and usability testing
+- Collaborate with PMs and Developers to ensure feasibility and clarity
+- Uphold design system standards and accessibility
+
+### Goals
+- Deliver highly usable and delightful product experiences
+- Align design with product vision and constraints
+
+### Typical Communication
+- Design reviews
+- User testing outcomes
+- Design handoffs (Figma/specs) to Developers
+
+---
+
+## Technical Writer
+
+### Role Summary
+Documents features, APIs, release notes, user guides, and process changes to ensure clear knowledge transfer and onboarding.
+
+### Responsibilities
+- Create and maintain technical documentation
+- Work with team to capture updates and clarify complex topics
+- Ensure docs are accurate, discoverable, and up to date
+
+### Goals
+- Enable effective onboarding and support
+- Reduce knowledge silos
+
+### Typical Communication
+- PRs for docs
+- Documentation review sessions
+
+---
+
+## QA Lead
+
+### Role Summary
+Drives test strategy, coordinates test planning, ensures quality standards, and tracks defect resolution.
+
+### Responsibilities
+- Define and maintain test plans/cases
+- Organize manual and automated testing
+- Work with Developers to ensure test coverage standards
+- Own defect tracking, reporting, and regression cycles
+
+### Goals
+- Minimize escaped defects
+- Improve test effectiveness and coverage
+- Collaborate for shift-left quality
+
+### Typical Communication
+- Test case reviews in planning
+- Quality status in standups
+
+---
+
+## Business Analyst
+
+### Role Summary
+Bridges business needs with technical solutions, gathering and clarifying requirements from stakeholders.
+
+### Responsibilities
+- Elicit, document, and prioritize requirements
+- Collaborate on acceptance criteria
+- Validate deliverables meet business goals
+
+### Goals
+- Reduce ambiguity in project scope
+- Improve alignment and stakeholder satisfaction
+
+### Typical Communication
+- Requirement workshop meetings
+- Written specs and requirement docs
+
+---
+
 ## How these personas are used in the exercise
+
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
 - Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
-


### PR DESCRIPTION
## Summary

This PR expands the project management documentation by adding new personas/roles to `docs/octoacme-roles-and-personas.md`:
- Scrum Master / Agile Coach
- UX/UI Designer
- Technical Writer
- QA Lead
- Business Analyst

For each, detailed responsibilities, goals, typical communication, and collaboration touchpoints are provided.

**Optional:** Added a role assignment and onboarding checklist as `docs/octoacme-role-assignment-checklist.md`.

## Rationale

Addresses [#4](https://github.com/henesp71/skills-scale-institutional-knowledge-using-copilot-spaces/issues/4): As PM processes grow in scope and complexity, clear definitions of all supporting roles improves transparency, collaboration, and accountability. These updates help teams avoid gaps in ownership, accelerate onboarding, and ensure best practices as roles diversify.

---

- [x] Updates align with documentation structure in `docs/`
- [x] Improves clarity and closes role responsibility gaps
- [x] Linked to #4 for traceability

/cc @henesp71